### PR TITLE
Include highlighting in the guide search results

### DIFF
--- a/_includes/index-docs.html
+++ b/_includes/index-docs.html
@@ -5,7 +5,7 @@
 {% assign by_type = index.quarkus | map: "types" | first %}
 
 <div id="guides-app"
-     data-url="{{ site.search.url }}"
+     data-search-api-server="{{ site.search.url }}"
      data-initial-timeout="{{ site.search.initial-timeout }}"
      data-more-timeout="{{ site.search.more-timeout }}"
      data-min-chars="{{ site.search.min-chars }}"
@@ -51,11 +51,15 @@
         </div>
       </Transition>
       <div class="grid-wrapper">
-        <div v-for="card in cardHits"
-            v-html="card.innerHTML"
-            class="grid__item docs-card"
-            :class="Array.from(card.classList)">
+        {% raw %}
+        <div v-for="hit in searchHits" :class="`${hit.type}bkg grid__item docs-card`">
+          <h4><a :href="hit.url" :target="hit.url.startsWith('http') ? '_blank' : ''" v-html="hit.title"></a></h4>
+          <div class="description" v-html="hit.summary"></div>
+          <div class="content-highlights">
+            <p v-for="contentLine in hit.content" v-html="contentLine"></p>
+          </div>
         </div>
+        {% endraw %}
         <Transition name="fade-in">
           <div v-if="loading" class="loading-placeholder">
             Loading...
@@ -92,7 +96,7 @@
       </div>
       <div class="grid-wrapper">
         {% for guide in values %}
-        {% include index-doc-item.html class="guidebkg" docversion=docversion
+        {% include index-doc-item.html class="howtobkg" docversion=docversion
           title=guide.title url=guide.url summary=guide.summary
           keywords=guide.keywords categories=guide.categories origin=guide.origin %}
         {% endfor %}
@@ -108,7 +112,7 @@
       </div>
       <div class="grid-wrapper">
         {% for guide in values %}
-        {% include index-doc-item.html class="conceptbkg" docversion=docversion
+        {% include index-doc-item.html class="conceptsbkg" docversion=docversion
           title=guide.title url=guide.url summary=guide.summary
           keywords=guide.keywords categories=guide.categories origin=guide.origin %}
         {% endfor %}
@@ -147,7 +151,7 @@
       </div>
       <div class="grid-wrapper">
         {% for guide in values %}
-        {% include index-doc-item.html class="referencebkg" docversion=docversion
+        {% include index-doc-item.html class="guidebkg" docversion=docversion
           title=guide.title url=guide.url summary=guide.summary
           keywords=guide.keywords categories=guide.categories origin=guide.origin %}
         {% endfor %}

--- a/_includes/index-guides.html
+++ b/_includes/index-guides.html
@@ -2,7 +2,7 @@
 {% assign data_source = include.source %}
 
 <div id="guides-app"
-     data-url="{{ site.search.url }}"
+     data-search-api-server="{{ site.search.url }}"
      data-initial-timeout="{{ site.search.initial-timeout }}"
      data-more-timeout="{{ site.search.more-timeout }}"
      data-min-chars="{{ site.search.min-chars }}"
@@ -28,70 +28,70 @@
     <div>
       <h1 class="title">{{ page.title }}</h1>
     </div>
-    <div v-if="hasInput" class="grid-wrapper guides results vuejs"
-         :class="{ empty: !loading && !hasHits, 'vuejs-enabled': true, loading: loading }">
-      <div class="grid__item width-12-12 click-cards">
-        <Transition name="fade-in">
-          <div v-if="!loading && !hasHits" class="empty-placeholder">
-            Sorry, no guides matched your search. Please try again.
-          </div>
-        </Transition>
-        <Transition name="fade-in">
-            <div v-if="!loading && !hasHits" class="empty-placeholder">
-                Sorry, no guides matched your search. Please try again.
-            </div>
-        </Transition>
-        <ul class="list">
-          <li>
-            <ul class="grid-wrapper list-item">
-              <li v-for="card in cardHits"
-                  v-html="card.innerHTML"
-                  class="card"
-                  :class="Array.from(card.classList)">
-              </li>
+    <div class="grid-wrapper guides" id="docs">
+        <div :class="`grid__item width-6-12 width-12-12-m guide-categories callout-wrapper ${!loading && hasHits ? 'hidden' : ''}`">
+            <h3>View Category</h3>
+            <ul>
+                {% for item in site.data[data_source].categories %}
+                <li>
+                    <a href="#{{ item.cat-id }}">{{ item.category }}</a>
+                </li>
+                {% endfor %}
             </ul>
-          </li>
-        </ul>
-        <Transition name="fade-in">
-            <div v-if="loading" class="loading-placeholder">
-                Loading...
+        </div>
+
+        <div class="grid__item width-6-12 width-12-12-m callout-wrapper">
+            <div class="grid-wrapper callout">
+                <div class="grid__item width-12-12">
+                    <h3>Quarkus Cheat Sheet</h3>
+                </div>
+                <div class="grid__item col">
+                    <a href="https://lordofthejars.github.io/quarkus-cheat-sheet/" target="_blank">
+                        <span class="col-icon"><i class="far fa-file-pdf"></i></span>
+                        <span class="col-link">Download full cheatsheet as PDF</span>
+                    </a>
+                </div>
+                <div class="grid__item col">
+                    <a href="https://developers.redhat.com/search?t=quarkus&f=type%7Echeatsheet" target="_blank">Get more cheatsheets on the Red Hat Developers website <i class="fas fa-external-link-alt"></i></a>
+                </div>
             </div>
-        </Transition>
-      </div>
-    </div>
+        </div>
+        <div v-if="hasInput" class="grid__item width-12-12 click-cards vuejs"
+             :class="{ empty: !loading && !hasHits, 'vuejs-enabled': true, loading: loading }">
+            <Transition name="fade-in">
+                <div v-if="!loading && !hasHits" class="empty-placeholder">
+                    Sorry, no guides matched your search. Please try again.
+                </div>
+            </Transition>
+            <ul class="list results">
+                <li>
+                    <ul class="grid-wrapper list-item">
+                        {% raw %}
+                        <li class="card" v-for="hit in searchHits">
+                            <a :href="hit.url" :target="hit.url.startsWith('http') ? '_blank' : ''"></a>
+                            <p class="title" v-html="hit.title"></p>
+                            <div class="description" v-html="hit.summary"></div>
+                            <div class="content-highlights">
+                                <p v-for="contentLine in hit.content" v-html="contentLine"></p>
+                            </div>
+                            <div class="origin" v-if="hit.url.startsWith('http')">
+                                <img src="/assets/images/quarkiverse_icon_default.svg" width="25" height="25"/>
+                                <span>Quarkiverse Hub</span>
+                            </div>
+                        </li>
+                        {% endraw %}
+                    </ul>
+                </li>
+            </ul>
+            <Transition name="fade-in">
+                <div v-if="loading" class="loading-placeholder">
+                    Loading...
+                </div>
+            </Transition>
+        </div>
     <!-- Static content displayed when there is no input in the search form or Javascript is disabled,
          but also used as a source of data for cards displayed by the vue.js app. -->
-    <div v-else class="grid-wrapper guides" id="docs">
-
-      <div class="grid__item width-6-12 width-12-12-m guide-categories callout-wrapper">
-        <h3>View Category</h3>
-          <ul>
-          {% for item in site.data[data_source].categories %}
-            <li>
-              <a href="#{{ item.cat-id }}">{{ item.category }}</a>
-            </li>
-          {% endfor %}
-          </ul>
-      </div>
-
-      <div class="grid__item width-6-12 width-12-12-m callout-wrapper">
-        <div class="grid-wrapper callout">
-           <div class="grid__item width-12-12">
-             <h3>Quarkus Cheat Sheet</h3>
-           </div>
-           <div class="grid__item col">
-            <a href="https://lordofthejars.github.io/quarkus-cheat-sheet/" target="_blank">
-              <span class="col-icon"><i class="far fa-file-pdf"></i></span>
-              <span class="col-link">Download full cheatsheet as PDF</span>
-            </a>
-           </div>
-           <div class="grid__item col">
-             <a href="https://developers.redhat.com/search?t=quarkus&f=type%7Echeatsheet" target="_blank">Get more cheatsheets on the Red Hat Developers website <i class="fas fa-external-link-alt"></i></a>
-           </div>
-        </div>
-      </div>
-
-      <div class="grid__item width-12-12 click-cards">
+      <div v-else class="grid__item width-12-12 click-cards">
         <ul class="list">
         {% for item in site.data[data_source].categories %}
           <li>

--- a/_sass/includes/whitecards.scss
+++ b/_sass/includes/whitecards.scss
@@ -119,6 +119,18 @@ grid-column: span 3;
         line-height: 1.1rem;
         }
 
+      span.highlighted {
+        font-weight: bold;
+        font-style: italic;
+        line-height: inherit;
+      }
+
+      .content-highlights p {
+        font-size: .7rem;
+        line-height: .8rem;
+        opacity: 0.8;
+      }
+
       &:hover, &:focus {
         background-color: $light-blue;
         border:1px solid $light-blue;

--- a/_sass/layouts/documentation.scss
+++ b/_sass/layouts/documentation.scss
@@ -252,6 +252,16 @@ Styles for the documentation index page
       }
     }
 
+    .content-highlights {
+      margin: 1rem 0 0 90px;
+      p {
+        font-size: .7rem;
+        line-height: .8rem;
+        opacity: 0.8;
+        margin-bottom: .5rem;
+      }
+    }
+
     &.quarkiverse .origin {
       padding-left: 120px;
       text-align: left;
@@ -267,6 +277,12 @@ Styles for the documentation index page
       position: absolute; 
       left: 90px;
     }
+
+    span.highlighted {
+      font-weight: bold;
+      color: inherit;
+      line-height: inherit;
+    }
   }
 
   .tutorialbkg {
@@ -275,11 +291,16 @@ Styles for the documentation index page
   }
 
   .guidebkg {
+    background: url($baseurl + '/assets/images/documentation/docsicon-referencedocs.svg') no-repeat;
+    background-size: 80px 80px;
+  }
+
+  .howtobkg {
     background: url($baseurl + '/assets/images/documentation/docsicon-guides.svg') no-repeat;
     background-size: 80px 80px;
   }
 
-  .conceptbkg {
+  .conceptsbkg {
     background: url($baseurl + '/assets/images/documentation/docsicon-concepts.svg') no-repeat;
     background-size: 80px 80px;
   }


### PR DESCRIPTION
Since we have some "dynamic" content form the highlights, we can't rely on pre-rendered static cards anymore, so the idea was to salvage whatever we can from the static card 😄 convert it to an "object" and use those to fill the blanks in the search response ... ideally it would've been nice if we just return that data from the search service, but I wasn't sure if we want to add more stuff to it... 